### PR TITLE
Fix parsing variable names starting with 'or' or 'and'

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -182,7 +182,7 @@ class Expression():
                 n1 = nstack.pop()
                 f = item.index_
                 if f == '-':
-                    nstack.append('(' + f + n1 + ')')
+                    nstack.append('(' + f + str(n1) + ')')
                 else:
                     nstack.append(f + '(' + n1 + ')')
             elif type_ == TFUNCALL:
@@ -654,8 +654,8 @@ class Parser:
             ('>=', 1, '>='),
             ('<', 1, '<'),
             ('>', 1, '>'),
-            ('and', 0, 'and'),
-            ('or', 0, 'or'),
+            ('and ', 0, 'and'),
+            ('or ', 0, 'or'),
         )
         for token, priority, index in ops:
             if self.expression.startswith(token, self.pos):

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -70,6 +70,7 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(parser.parse("(a**2-b**2)==((a+b)*(a-b))").evaluate({'a': 4859, 'b': 13150}), True)
         self.assertEqual(parser.parse("(a**2-b**2+1)==((a+b)*(a-b))").evaluate({'a': 4859, 'b': 13150}), False)
         self.assertExactEqual(parser.parse("x/((x+y))").simplify({}).evaluate({'x':1, 'y':1}), 0.5)
+        self.assertExactEqual(parser.parse('origin+2.0').evaluate({'origin': 1.0}), 3.0)
 
         #functions
         self.assertExactEqual(parser.parse('pyt(2 , 0)').evaluate({}), 2.0)


### PR DESCRIPTION
Variable names starting with 'or' or 'and' were parsed as boolean operators **or** or **and** by mistake.